### PR TITLE
fix: remove description output

### DIFF
--- a/.actor/dataset_schema.json
+++ b/.actor/dataset_schema.json
@@ -19,11 +19,6 @@
                 "description": "The rating of the product.",
                 "nullable": true
             },
-            "description": {
-                "type": "string",
-                "description": "The description of the product.",
-                "nullable": true
-            },
             "price": {
                 "type": "object",
                 "description": "The price of the product.",
@@ -66,7 +61,6 @@
                     "title",
                     "brand",
                     "stars",
-                    "description",
                     "url",
                     "price",
                     "reviewSummary"

--- a/src/models.py
+++ b/src/models.py
@@ -29,7 +29,6 @@ class AmazonProduct(BaseModel):
     title: The title of the product.
     brand: The brand of the product.
     stars: The rating of the product.
-    description: The description of the product.
     price: The price of the product.
     url: The URL of the product.
     """
@@ -37,7 +36,6 @@ class AmazonProduct(BaseModel):
     title: str
     brand: str | None = None
     stars: float | None = None
-    description: str | None = None
     price: AmazonProductPrice | None = None
     url: str | None = None
     features: list[str] | None = None

--- a/src/tools.py
+++ b/src/tools.py
@@ -87,7 +87,7 @@ async def tool_scrape_amazon_products(
         title: str | None = item.get('title')
         brand: str | None = item.get('brand')
         stars: int | None = item.get('stars')
-        description: str | None = item.get('description')
+        description: str | None = item.get('description') # Not used since amazon-crawler returns only null
         price: dict | None = item.get('price')
         url: str | None = item.get('url')
         features: list[str] | None = item.get('features')
@@ -97,7 +97,6 @@ async def tool_scrape_amazon_products(
                 title=title,
                 brand=brand,
                 stars=stars,
-                description=description,
                 price=AmazonProductPrice(**price) if price else None,
                 url=url,
                 features=features,


### PR DESCRIPTION
Amazon-crawler always returns null in description field